### PR TITLE
Bug fix. Fixed wrong conversion between ole date and posix date

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -436,4 +436,7 @@ public:
 	virtual HRESULT STDMETHODCALLTYPE Invoke(DISPID dispIdMember, REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams, VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr);
 };
 
+double FromOleDate(double);
+double ToOleDate(double);
+
 //-------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Bug fix. Fixed wrong coversion between ole date and posix date.
From OLE Date type documentation:
The DATE type is implemented using an 8-byte floating-point number. Days are represented by whole number increments starting with 30 December 1899, midnight as time zero. Hour values are expressed as the absolute value of the fractional part of the number.