### PR TITLE
support property put: obj.method('foo') = 'bar'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "winax",
+  "version": "1.13.0",
+  "lockfileVersion": 1
+}

--- a/src/disp.cpp
+++ b/src/disp.cpp
@@ -215,7 +215,15 @@ void DispObject::call(Isolate *isolate, const FunctionCallbackInfo<Value> &args)
         hrcode = disp->ExecuteMethod(dispid, argcnt, pargs, &ret, &except);
     }
     else {
-        hrcode = disp->GetProperty(dispid, argcnt, pargs, &ret, &except);
+        DispInfo::type_ptr disp_info;
+		disp->GetTypeInfo(dispid, disp_info);
+
+		if(disp_info->is_property_advanced() && argcnt > 1) {
+			hrcode = disp->SetProperty(dispid, argcnt, pargs, &ret, &except);
+		}
+		else {
+			hrcode = disp->GetProperty(dispid, argcnt, pargs, &ret, &except);
+		}
     }
     if FAILED(hrcode) {
         isolate->ThrowException(DispError(isolate, hrcode, L"DispInvoke", name.c_str(), &except));

--- a/src/disp.h
+++ b/src/disp.h
@@ -36,6 +36,7 @@ public:
 		inline bool is_property() const { return ((kind & INVOKE_FUNC) == 0); }
 		inline bool is_property_simple() const { return (((kind & (INVOKE_PROPERTYGET | INVOKE_FUNC))) == INVOKE_PROPERTYGET) && (argcnt_get == 0); }
 		inline bool is_function_simple() const { return (((kind & (INVOKE_PROPERTYGET | INVOKE_FUNC))) == INVOKE_FUNC) && (argcnt_get == 0); }
+		inline bool is_property_advanced() const { return kind == (INVOKE_PROPERTYGET | INVOKE_PROPERTYPUT) && (argcnt_get == 1); }
 	};
 	typedef std::shared_ptr<type_t> type_ptr;
 	typedef std::map<DISPID, type_ptr> types_by_dispid_t;


### PR DESCRIPTION
Fixes #61

obj.method('foo') = 'bar'
in NodeJS ->
obj.method('foo', 'bar');