### PR TITLE
Fix in Variant2Array for SAFEARRAY with lLbound != 0

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -87,7 +87,8 @@ Local<Value> Variant2Array(Isolate *isolate, const VARIANT &v) {
 		CComVariant vi;
 		if SUCCEEDED(SafeArrayGetElement(varr, &i, (vt == VT_VARIANT) ? (void*)&vi : (void*)&vi.byref)) {
 			if (vt != VT_VARIANT) vi.vt = vt;
-			arr->Set(ctx, (uint32_t)i, Variant2Value(isolate, vi, true));
+			uint32_t jsi = i - varr->rgsabound[ 0 ].lLbound;
+			arr->Set(ctx, jsi, Variant2Value(isolate, vi, true));
 		}
 	}
 	return arr;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -83,7 +83,7 @@ Local<Value> Variant2Array(Isolate *isolate, const VARIANT &v) {
 	VARTYPE vt = v.vt & VT_TYPEMASK;
 	LONG cnt = (LONG)varr->rgsabound[0].cElements;
 	Local<Array> arr = Array::New(isolate, cnt);
-	for (LONG i = varr->rgsabound[0].lLbound; i < cnt; i++) {
+	for (LONG i = varr->rgsabound[0].lLbound; i < varr->rgsabound[0].lLbound + cnt; i++) {
 		CComVariant vi;
 		if SUCCEEDED(SafeArrayGetElement(varr, &i, (vt == VT_VARIANT) ? (void*)&vi : (void*)&vi.byref)) {
 			if (vt != VT_VARIANT) vi.vt = vt;


### PR DESCRIPTION
Hi durs,

Excel generally returns SAFEARRAY with the first index of each dimension set to 1, not 0. I think it is related to some sort of Legacy about Excel Macro, VBA, and the ancestors of COM.

While modifying your code to be able to process two dimensional SAFEARRAY ((which is somehow mandatory  if you want to interact with Excel), I found this bug on the lower limits, therefore this PR.

Would you be interested in another PR allowing Variant2Array to process two dimensional SAFEARRAY (returning a JS array of arrays, in this case)?

Manuel