### PR TITLE
Variant2Array: Calling a new dedicated function (Variant2Array2)

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -343,6 +343,7 @@ inline INTTYPE Variant2Int(const VARIANT &v, const INTTYPE def) {
 }
 
 Local<Value> Variant2Array(Isolate *isolate, const VARIANT &v);
+Local<Value> Variant2Array2(Isolate *isolate, const VARIANT &v);
 Local<Value> Variant2Value(Isolate *isolate, const VARIANT &v, bool allow_disp = false);
 Local<Value> Variant2String(Isolate *isolate, const VARIANT &v);
 void Value2Variant(Isolate *isolate, Local<Value> &val, VARIANT &var, VARTYPE vt = VT_EMPTY);


### PR DESCRIPTION
Hi,
when trying to automate Excel, it is very handy, performance-wise, to be able to read large numbers of cells, using a rectangular "Range".

This PR calls a dedicated function when Variant2Array detects that the SAFEARRAY is a bidimentional one.
The new function (called Variant2Array2) is very largely a variation of  Variant2Array, except that there is two loops instead of one. The return value is a JavaScript Array of JavaScript Arrays.
The most significant dimension is conventionally the rightmost in the SAFEARRAY.

With this PR, the following JavaScript code works:

```
const ActiveX = require('./build/debug/node_activex.node');
let comExcelApp = new ActiveX.Object("Excel.Application");
comExcelApp.Visible = true;
comExcelApp.Workbooks.Add();
let w = comExcelApp.ActiveSheet;
w.Range("A1").Value = "A1";
w.Range("A2").Value = "A2";
w.Range("A3").Value = "A3";
w.Range("B1").Value = "B1";
w.Range("B2").Value = "B2";
w.Range("B3").Value = "B3";
let Rect = w.Range("A1:B3").Value.__value;
console.log( 'A1:B3 Value is ' + Rect );
```
The output is:
A1:B3 Value is A1,B1,A2,B2,A3,B3
and the Visual Code debugger shows that Rect is indeed a native JavaScript Array of 3 "rows" each of them being a JavaScript Array of 2 columns.

Please let me know what you think about that code.