### PR TITLE
Supply pointer to an existing instance (e.g. existing instance of Excel)

### DIFF
--- a/src/disp.cpp
+++ b/src/disp.cpp
@@ -510,6 +510,19 @@ void DispObject::NodeCreate(const FunctionCallbackInfo<Value> &args) {
 		}
 	}
 
+	// Use supplied dispatch pointer
+	else if (args[0]->IsUint8Array()) {
+		Local<Uint8Array> input = args[0].As<Uint8Array>();
+		if (input->Length() != sizeof(INT_PTR)) {
+			isolate->ThrowException(InvalidArgumentsError(isolate));
+			return;
+		}
+		void *data = input->Buffer()->GetContents().Data();
+		IDispatch* p = (IDispatch *) *(static_cast<INT_PTR*>(data));
+		disp = CComPtr<IDispatch>(p);
+		hrcode = S_OK;
+	}
+
 	// Create dispatch object from javascript object
 	else if (args[0]->IsObject()) {
 		name = L"#";


### PR DESCRIPTION
For my use case I have obtained a pointer already via GetAccessibleObjectFromWindow and wanted my javascript object to be instantiated using that instead of creating a new Excel instance. Please consider adding this.  (also relevant wrt #47 )

Since node version was set to >= 4.0.0, I have chosen for the uint8Array. Alternatively, this can be done using a BigInt. (This would require the minimum node major version >= 10, if I am not mistaken)

```
// Use supplied dispatch pointer
else if (args[0]->IsBigInt()) {
	bool lossless;
	IDispatch* p = (IDispatch *) (Local<BigInt>::Cast(args[0]))->Uint64Value(&lossless);
	disp = CComPtr<IDispatch>(p);
	hrcode = S_OK;
}
```