### PR TITLE
Full emulation of WScript

### DIFF
--- a/NodeWScript.js
+++ b/NodeWScript.js
@@ -1,0 +1,349 @@
+var g_winax = require('winax');
+var path = require('path');
+
+if(process.argv.length<3)
+{
+    console.error("Missing argument. Usage:\nnodewscript SomeJS.js <other arguments>")
+}
+
+global.SeSIncludeFile = function (includePath, isLocal, ctx) {
+
+    var vm = require("vm");
+
+    var fs = require("fs");
+    var path = require("path");
+
+    var absolutePath = path.resolve(includePath);
+    //console.log('Incl: '+absolutePath)
+    var data = fs.readFileSync(absolutePath);
+    var script = new vm.Script(data, { filename: absolutePath, displayErrors: true });
+    if (isLocal && ctx) {
+        if (!ctx.__runctx__) ctx.__runctx__ = vm.createContext(ctx);
+        script.runInContext(ctx.__runctx__);
+    } else {
+        //script.runInContext(global.__rapise_global_context__);
+        script.runInThisContext();
+    }
+
+    return '';
+    //return 'console.log("Done: "+'+JSON.stringify(absolutePath) +')';    
+};
+
+var WinAXActiveXObject = ActiveXObject;
+
+function ActiveXObjectCreate(progId, pfx)
+{
+    var res = new WinAXActiveXObject(progId);
+    if(progId=="SeSHelper")
+    {
+        // SeSHelper implements Include that we want to override
+        res = new Proxy({helper:res}, {
+            get(target, propKey, receiver) {
+                return function (...args) {
+                    var helper = target.helper;
+                    var ovr =
+                    {
+                        IncludeLocal(/**Object*/fName, ctx) /**Object*/
+                        {
+                            return this.Include(fName, true, ctx);
+                        },
+                
+                        Include(/**Object*/fName, local, ctx) /**Object*/
+                        {
+                            var includePath = helper.ResolvePath(fName);
+                            if(!includePath)
+                            {
+                                var err = "Error trying to include file. File not found:"+fName;
+                                return "console.error("+JSON.stringify(err)+")";
+                            }
+                        
+                            if(!local) 
+                            {
+                                helper.SetAlreadyIncluded(includePath);
+                            }
+                    
+                            return global.SeSIncludeFile(includePath, local, ctx);
+                    
+                        },
+                
+                        IncludeOnce(/**Object*/fName) /**Object*/
+                        {
+                            if(!helper.IsAlreadyIncluded(fName))
+                            {
+                                return this.Include(fName);
+                            }
+                            return "";
+                        }
+                    }
+
+                    if(propKey in ovr)
+                    {
+                        return ovr[propKey](...args);
+                    } else {
+                        let result = target.helper[propKey](...args);
+                        return result;    
+                    }
+
+                };
+            }
+          });
+    }
+
+    if(res&&pfx)
+    {
+        WScript.ConnectObject(res, pfx);
+    }
+    
+    return res;
+}
+
+global.ActiveXObject=new Proxy(ActiveXObject, {
+    construct(target,args)
+    {
+        //console.log("Creating ActiveXObject: "+args);
+        return ActiveXObjectCreate(...args);
+    }
+});
+
+global.Enumerator = function (arr) {
+    this.arr = arr;
+    this.enum = arr._NewEnum;
+    this.nextItem = null;
+    this.atEnd = function () { return this.nextItem===undefined; }
+    this.moveNext = function () {  this.nextItem = this.enum.Next(1); return this.atEnd(); }
+    this.moveFirst = function () { this.enum.Reset(); this.nextItem=null; return this.moveNext(); }
+    this.item = function () { return this.nextItem; }
+    
+    this.moveNext();
+}
+
+// See interface here
+// https://www.devguru.com/content/technologies/wsh/objects-wscript.html
+
+var WScript = {
+    // Properties
+    Application : null,
+    BuildVersion : "6.0",
+    FullName : null,
+    Interactive : true,
+    Name : "Windows / Node Script Host",
+    Path : __filename,
+    ScriptFullName : null,
+    ScriptName : null,
+    StdErr: {
+        Write(txt) { console.log(txt); }
+    },
+    StdIn: {
+        ReadLine() { 
+            var readline = require('readline');
+            var gotLine = false;
+            var line = undefined;
+
+            var rl = readline.createInterface({
+              input: process.stdin,
+              output: process.stdout,
+              terminal: false
+            });
+            
+            rl.on('line', function (cmd) {
+                line = cmd;
+                rl.close();
+            });
+            while(!gotLine)
+            {
+                WScript.Sleep(10);
+            }
+            return line
+        }
+    },
+    StdOut: {
+        Write(txt) { console.err(txt); }
+    },
+    Timeout : -1,
+    Version : 'NODE.WIN32',
+
+    // Methods
+    
+    Echo : console.log,
+
+    __Connected : [],
+
+    ConnectObject(obj, pfx)
+    {
+        var connectionPoints = g_winax.getConnectionPoints(obj);
+        var connectionPoint = connectionPoints[0];
+        var allMethods = connectionPoint.getMethods();
+
+        var advobj={};
+        var found = false;
+        for(var i=0;i<allMethods.length;i++)
+        {
+            var a = allMethods[i];
+            
+            var cpFunc = null;
+            var fName = pfx + a;
+            
+            eval('if(typeof '+fName+'!="undefined") cpFunc = '+fName+';')
+
+            if(cpFunc)
+            {
+                found = true;
+                advobj[a]=cpFunc;
+            }
+        }
+
+        if(found)
+        {
+            var dwCookie = connectionPoint.advise(advobj);
+            this.__Connected.push({obj,pfx,connectionPoint,dwCookie});
+        }
+
+    },
+
+    DisconnectObject(obj)
+    {
+        for(var i=0;i<this.__Connected.length;i++)
+        {
+            var o = this.__Connected[i];
+            if(o.obj==obj)
+            {
+                o.connectionPoint.unadvise(o.dwCookie);
+                // Remove connection from list
+                this.__Connected.splice(i,1);
+                break;
+            }
+        }
+    },
+    
+    CreateObject : ActiveXObjectCreate,
+
+    GetObject : ActiveXObjectCreate,
+
+    Quit (exitCode) { 
+        // Gracefully disconnect and release all ActiveX objects, if needed
+        while(this.__Connected.length>0)
+        {
+            WScript.DisconnectObject(this.__Connected[0].obj);
+        }
+        clearInterval(g_runtime_connection_handler);
+        WScript.Sleep(60);
+        process.exit(exitCode); 
+    },
+
+    Sleep (ms) { 
+        var begin = (new Date()).valueOf();
+        MessageLoop();
+        var dt = (new Date()).valueOf()-begin;
+
+        while(dt<ms)
+        {
+            MessageLoop();
+            g_winax.winaxsleep(1);
+            dt = (new Date()).valueOf()-begin;
+        }
+    },
+
+    __Args : process.argv,
+    __ShowLogo : true,
+    __Debug : false,
+
+    // Collections
+    Arguments : null,
+
+    __InitArgs(){
+        this.Application = this;
+        this.__Args=[];
+        for(let i=0;i<process.argv.length;i++)
+        {
+            if(i==0)
+            {
+                this.FullName = path.resolve(process.argv[0])
+            } else if(i==1) {
+                this.Name = process.argv[1];
+            } else if(i==2) {
+                this.ScriptFullName = path.resolve(process.argv[2]);
+                this.ScriptName = path.basename(this.ScriptFullName);
+            } else {
+                // All other args
+                var arg = process.argv[i];
+                if(arg.startsWith("//"))
+                {
+/* 
+Parse all arguments and process those related to core WScript:
+ //B         Batch mode: Suppresses script errors and prompts from displaying
+ //D         Enable Active Debugging
+ //E:engine  Use engine for executing script
+ //H:CScript Changes the default script host to CScript.exe
+ //H:WScript Changes the default script host to WScript.exe (default)
+ //I         Interactive mode (default, opposite of //B)
+ //Job:xxxx  Execute a WSF job
+ //Logo      Display logo (default)
+ //Nologo    Prevent logo display: No banner will be shown at execution time
+ //S         Save current command line options for this user
+ //T:nn      Time out in seconds:  Maximum time a script is permitted to run
+ //X         Execute script in debugger
+ //U         Use Unicode for redirected I/O from the console
+*/
+                    if(arg.toLowerCase()=="//nologo")
+                    {
+                        this.__ShowLogo = false;
+                    } else if(arg.toLowerCase().indexOf("//t:")==0) {
+                        var timeOut = parseInt(arg.substr("//t:".length));
+                        this.Timeout = timeOut;
+                        setTimeout(()=>{WScript.Quit(0);},timeOut*1000)
+                    } else if(arg.toLowerCase()=="//x"||arg.toLowerCase()=="//d") {
+                        this.__Debug = true;
+                    }
+                } else {
+                    this.__Args.push(arg);
+                }
+            }
+        }
+
+        // The trick starts here
+        // We want WScript.Arguments to be accessible in all of the following ways:
+        // WScript.Arguments(i)
+        // WScript.Arguments.item(i)
+        // WScript.Arguments.length
+        // Since it is not directly possible, we use a number of tricks.
+        // Function.length is a number of expected arguments
+        // And we make this 'fake' number
+        var argArr=[];
+        for(var ai=0;ai<WScript.__Args.length;ai++)argArr.push("arg"+ai);
+        var ArgF=null;
+        eval("ArgF = function ("+argArr.join(",")+") { return WScript.__Args[arguments[0]];  }");
+        ArgF.item = function(i) { return WScript.__Args[i] };
+        ArgF.toString = function() { return WScript.__Args.join(' '); }
+
+        this.Arguments = ArgF;
+    }
+}
+
+WScript.__InitArgs();
+
+global.WScript = WScript;
+
+if(WScript.__ShowLogo)
+{
+    WScript.Echo(WScript.Name+" "+WScript.BuildVersion);
+}
+
+function MessageLoop()
+{
+    g_winax.peekAndDispatchMessages(); // allows ActiveX event to be dispatched
+}
+
+var g_runtime_connection_handler = setInterval(()=>{/**MessageLoop();*/}, 1);
+
+const __rapise_global_context__ = require("vm").createContext(this);
+global.__rapise_global_context__ = __rapise_global_context__;
+
+if(WScript.ScriptFullName)
+{
+    SeSIncludeFile(WScript.ScriptFullName);
+} else {
+    WScript.StdErr.Write("File.js missing.\nUsage wscriptnode <File.js>")
+}
+
+WScript.Quit(0);
+

--- a/NodeWScript.js
+++ b/NodeWScript.js
@@ -131,7 +131,7 @@ var WScript = {
     ScriptFullName : null,
     ScriptName : null,
     StdErr: {
-        Write(txt) { console.log(txt); }
+        Write(txt) { console.log(txt); MessageLoop();}
     },
     StdIn: {
         ReadLine() { 
@@ -157,14 +157,14 @@ var WScript = {
         }
     },
     StdOut: {
-        Write(txt) { console.err(txt); }
+        Write(txt) { console.err(txt); MessageLoop(); }
     },
     Timeout : -1,
     Version : 'NODE.WIN32',
 
     // Methods
     
-    Echo : console.log,
+    Echo(txt) : { console.log(txt); MessageLoop(); },
 
     __Connected : [],
 
@@ -225,7 +225,7 @@ var WScript = {
         {
             WScript.DisconnectObject(this.__Connected[0].obj);
         }
-        clearInterval(g_runtime_connection_handler);
+        //clearInterval(g_runtime_connection_handler);
         WScript.Sleep(60);
         process.exit(exitCode); 
     },
@@ -333,11 +333,15 @@ function MessageLoop()
     g_winax.peekAndDispatchMessages(); // allows ActiveX event to be dispatched
 }
 
-var g_runtime_connection_handler = setInterval(()=>{/**MessageLoop();*/}, 1);
+// We don't need message loop here. Normally it works when we do one of Sleep, Echo, StdOut.Write
+// var g_runtime_connection_handler = setInterval(()=>{MessageLoop();}, 1);
 
 const __rapise_global_context__ = require("vm").createContext(this);
 global.__rapise_global_context__ = __rapise_global_context__;
 
+
+// We just evaluate the target script and then Quit. Since it may use Sleep then then end of evaluation would mean
+// end of script
 if(WScript.ScriptFullName)
 {
     SeSIncludeFile(WScript.ScriptFullName);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "winax",
-  "version": "1.19.0",
+  "version": "2.20.0",
   "lockfileVersion": 1
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,23 @@
 {
   "name": "winax",
-  "version": "2.20.0",
-  "lockfileVersion": 1
+  "version": "3.1.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "winax",
+      "version": "3.1.0",
+      "license": "MIT",
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "nodewscript": "NodeWScript.js"
+      },
+      "devDependencies": {},
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "winax",
-  "version": "1.20.0",
+  "version": "2.20.0",
   "description": "Windows COM bindings",
   "homepage": "https://github.com/durs/node-activex",
   "keywords": [
@@ -14,15 +14,20 @@
     "WSH",
     "WMI",
     "Excel",
-    "Word"
+    "Word",
+    "WScript",
+    "ConnectObject",
+    "DisconnectObject"
   ],
   "author": {
     "name": "durs",
     "url": "https://github.com/durs",
     "email": "yuri.dursin@gmail.com"
   },
+  "bin": {"nodewscript": "./NodeWScript.js"}
   "contributors": [
-    "durs <yuri.dursin@gmail.com>"
+    "durs <yuri.dursin@gmail.com>",
+    "Alexey Grinevich <alexey.grinevich@inflectra.com>"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "winax",
-  "version": "2.20.0",
+  "version": "3.1.0",
   "description": "Windows COM bindings",
   "homepage": "https://github.com/durs/node-activex",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "url": "https://github.com/durs",
     "email": "yuri.dursin@gmail.com"
   },
-  "bin": {"nodewscript": "./NodeWScript.js"}
+  "bin": {
+    "nodewscript": "./NodeWScript.js"
+  },
   "contributors": [
     "durs <yuri.dursin@gmail.com>",
     "Alexey Grinevich <alexey.grinevich@inflectra.com>"

--- a/src/disp.h
+++ b/src/disp.h
@@ -300,6 +300,8 @@ public:
 
 	static Local<Object> NodeCreateInstance(const FunctionCallbackInfo<Value> &args);
 	static void NodeCreate(const FunctionCallbackInfo<Value> &args);
+	static Local<Object> NodeCreate(Isolate* isolate, const VARIANT& var);
+
 	static void NodeClear(const FunctionCallbackInfo<Value> &args);
 	static void NodeAssign(const FunctionCallbackInfo<Value> &args);
 	static void NodeCast(const FunctionCallbackInfo<Value> &args);
@@ -309,6 +311,8 @@ public:
 	static void NodeSet(Local<Name> name, Local<Value> value, const PropertyCallbackInfo<Value> &args);
 	static void NodeGetByIndex(uint32_t index, const PropertyCallbackInfo<Value> &args);
 	static void NodeSetByIndex(uint32_t index, Local<Value> value, const PropertyCallbackInfo<Value> &args);
+
+
 
 private:
 	CComVariant value, pvalue;
@@ -326,7 +330,8 @@ public:
     static void NodeInit(const Local<Object> &target, Isolate* isolate, Local<Context> &ctx);
     static void NodeCreate(const FunctionCallbackInfo<Value> &args);
     static void NodeAdvise(const FunctionCallbackInfo<Value> &args);
-    static void NodeUnadvise(const FunctionCallbackInfo<Value> &args);
+	static void NodeUnadvise(const FunctionCallbackInfo<Value> &args);
+	static void NodeConnectionPointMethods(const FunctionCallbackInfo<Value> &args);
 
 private:
     bool InitIndex();
@@ -334,5 +339,7 @@ private:
     CComPtr<IConnectionPoint> ptr;
     CComPtr<IDispatch> disp;
     DispObjectImpl::index_t index;
+
 	std::unordered_set<DWORD> cookies;
+
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,13 @@ NODE_MODULE_INIT(/*exports, module, context*/) {
   VariantObject::NodeInit(exports, isolate, context);
   ConnectionPointObject::NodeInit(exports, isolate, context);
 
+  // Sleep is essential to have proper WScript emulation
+  exports->Set(context,
+      String::NewFromUtf8(isolate, "winaxsleep", NewStringType::kNormal)
+      .ToLocalChecked(),
+      FunctionTemplate::New(isolate, WinaxSleep)
+      ->GetFunction(context).ToLocalChecked()).FromJust();
+
   /* Example implementation of a context-aware addon:
   // Create a new instance of `AddonData` for this instance of the addon and
   // tie its life cycle to that of the Node.js environment.

--- a/test/ado.js
+++ b/test/ado.js
@@ -77,6 +77,11 @@ describe("ADODB.Connection", function() {
 
 describe("Release objects", function() {
     
+    it("try call", function() {
+        if (con) try { this.test.title += ': SUCCESS (' + con.Version + ')'; }
+        catch(e) { this.test.title += ': FAILED (' + e.message + ')'; }
+    });
+
     it("release", function() {
         this.test.title += ': ' + winax.release(fso, con, rs, fields);
     });
@@ -85,9 +90,5 @@ describe("Release objects", function() {
         this.test.title += ': ' + winax.release(fso, con, rs, fields);
     });
     
-    it("try call", function() {
-        if (con) try { this.test.title += ': SUCCESS (' + con.Version + ')'; }
-        catch(e) { this.test.title += ': FAILED (' + e.message + ')'; }
-    });
     
 });

--- a/test/wscript.js
+++ b/test/wscript.js
@@ -1,0 +1,33 @@
+const assert = require('assert');
+
+function r(name) {
+    const {execSync} = require('child_process')
+    execSync(__dirname+'/wscript/nodewscript_test_cli.cmd '+__dirname+'/wscript/'+name+'.js', {timeout: 10000})
+}
+
+describe("Execute WScript Tests", function() {
+
+    it('WScript Arguments', function (done) {
+        r('arguments');
+        done()
+    })
+
+    it('WScript Enumerator', function (done) {
+        r('enumerator');
+        done()
+    })
+
+
+    it('WScript Mixed', function (done) {
+        r('mixed');
+        done()
+    })
+
+    it('WScript WMI', function (done) {
+        r('wmi');
+        done()
+    })
+
+
+});
+

--- a/test/wscript/README.md
+++ b/test/wscript/README.md
@@ -1,0 +1,8 @@
+# WScript JScript samples
+
+Here we have a number of .js files taken from available tutorials and samples just as is. Our goal is to demonstrante that `nodewscript` may be used to launch them without any modification.
+
+`wmi.js` https://www.activexperts.com/admin/scripts/wmi/jscript/0383/
+
+`enumerator.js` https://gist.github.com/mlhaufe/1569247
+

--- a/test/wscript/arguments.js
+++ b/test/wscript/arguments.js
@@ -1,0 +1,8 @@
+WScript.Echo("Same count: " + (WScript.Arguments.length==WScript.Arguments.Count()) );
+
+objArgs = WScript.Arguments
+WScript.Echo(WScript.Arguments.Count());
+for (i=0; i<objArgs.length; i++)
+{
+    WScript.Echo(objArgs(i))
+}

--- a/test/wscript/enumerator.js
+++ b/test/wscript/enumerator.js
@@ -1,0 +1,31 @@
+//Reference: <https://groups.google.com/group/comp.lang.javascript/browse_thread/thread/684ad16518c837a2/67d00aa5dbe854c2?show_docid=67d00aa5dbe854c2>
+var listFileTypes = (function(){
+    var fso = new ActiveXObject("Scripting.FileSystemObject");
+    var shell = new ActiveXObject("WScript.Shell");
+
+    function isKnown(file){
+        var fName = file.Name;
+        //the rules of capitalization are strange in windows...
+        //there are rare cases where this can fail
+        //for example: .HKEY_CLASSES_ROOT\.HeartsSave-ms
+        var ext = fName.slice(fName.lastIndexOf(".")).toLowerCase();
+
+        try{
+            shell.RegRead("HKCR\\"+ext+"\\");
+            return "Yes"
+        } catch(e){
+            return "No"
+        }
+    }
+
+    return function(folder){
+        var files = new Enumerator(fso.GetFolder(folder).Files);
+        for(;!files.atEnd();files.moveNext()){
+            var file = files.item();
+            WScript.Echo(file.Name + "\t" + file.Type + "\t" + isKnown(file));
+        }
+    }
+})()
+
+
+listFileTypes("C:\\temp")

--- a/test/wscript/mixed.js
+++ b/test/wscript/mixed.js
@@ -1,0 +1,36 @@
+// This test should have both node and WScript mixed
+
+// First, we get count of files using FSO
+
+var fso = new ActiveXObject("Scripting.FileSystemObject");
+
+var filesCount = fso.GetFolder(".").Files.Count;
+
+WScript.Echo("FSO Path: "+fso.GetFolder(".").Path+" Files count: "+filesCount);
+
+// This if makes sure you still may run this file using cscript
+if(WScript.Version=='NODE.WIN32')
+{
+    // And then use node fs
+    console.log("path.resolve(.): "+require('path').resolve('.'));
+
+    var fs = require('fs');
+    var files = fs.readdirSync(".");
+
+    var nodeFilesCount = 0;
+    for(var f in files) 
+    {
+        if( !fs.lstatSync(files[f]).isDirectory() )
+        {
+            nodeFilesCount++;
+        }
+    }
+
+    if(nodeFilesCount!=filesCount)
+    {
+        console.log("FSO files: ", filesCount, "fs files: ", nodeFilesCount);
+        WScript.Quit(-5);
+    } else {
+        console.log("Same number of files: "+nodeFilesCount);
+    }
+}

--- a/test/wscript/nodewscript_test_cli.cmd
+++ b/test/wscript/nodewscript_test_cli.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\..\..\NodeWScript.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/test/wscript/wmi.js
+++ b/test/wscript/wmi.js
@@ -1,0 +1,112 @@
+  var wbemFlagReturnImmediately = 0x10;
+var wbemFlagForwardOnly = 0x20;
+
+var arrComputers = new Array(".");
+for (i = 0; i < arrComputers.length; i++) {
+   WScript.Echo();
+   WScript.Echo("==========================================");
+   WScript.Echo("Computer: " + arrComputers[i]);
+   WScript.Echo("==========================================");
+
+   var objWMIService = GetObject("winmgmts:\\\\" + arrComputers[i] + "\\root\\CIMV2");
+   var colItems = objWMIService.ExecQuery("SELECT * FROM Win32_ComputerSystem", "WQL",
+                                          wbemFlagReturnImmediately | wbemFlagForwardOnly);
+
+   var enumItems = new Enumerator(colItems);
+   for (; !enumItems.atEnd(); enumItems.moveNext()) {
+      var objItem = enumItems.item();
+
+      WScript.Echo("AdminPasswordStatus: " + objItem.AdminPasswordStatus);
+      WScript.Echo("AutomaticResetBootOption: " + objItem.AutomaticResetBootOption);
+      WScript.Echo("AutomaticResetCapability: " + objItem.AutomaticResetCapability);
+      WScript.Echo("BootOptionOnLimit: " + objItem.BootOptionOnLimit);
+      WScript.Echo("BootOptionOnWatchDog: " + objItem.BootOptionOnWatchDog);
+      WScript.Echo("BootROMSupported: " + objItem.BootROMSupported);
+      WScript.Echo("BootupState: " + objItem.BootupState);
+      WScript.Echo("Caption: " + objItem.Caption);
+      WScript.Echo("ChassisBootupState: " + objItem.ChassisBootupState);
+      WScript.Echo("CreationClassName: " + objItem.CreationClassName);
+      WScript.Echo("CurrentTimeZone: " + objItem.CurrentTimeZone);
+      WScript.Echo("DaylightInEffect: " + objItem.DaylightInEffect);
+      WScript.Echo("Description: " + objItem.Description);
+      WScript.Echo("DNSHostName: " + objItem.DNSHostName);
+      WScript.Echo("Domain: " + objItem.Domain);
+      WScript.Echo("DomainRole: " + objItem.DomainRole);
+      WScript.Echo("EnableDaylightSavingsTime: " + objItem.EnableDaylightSavingsTime);
+      WScript.Echo("FrontPanelResetStatus: " + objItem.FrontPanelResetStatus);
+      WScript.Echo("InfraredSupported: " + objItem.InfraredSupported);
+      try { WScript.Echo("InitialLoadInfo: " + (objItem.InitialLoadInfo.toArray()).join(",")); }
+         catch(e) { WScript.Echo("InitialLoadInfo: null"); }
+      WScript.Echo("InstallDate: " + WMIDateStringToDate(""+objItem.InstallDate));
+      WScript.Echo("KeyboardPasswordStatus: " + objItem.KeyboardPasswordStatus);
+      WScript.Echo("LastLoadInfo: " + objItem.LastLoadInfo);
+      WScript.Echo("Manufacturer: " + objItem.Manufacturer);
+      WScript.Echo("Model: " + objItem.Model);
+      WScript.Echo("Name: " + objItem.Name);
+      WScript.Echo("NameFormat: " + objItem.NameFormat);
+      WScript.Echo("NetworkServerModeEnabled: " + objItem.NetworkServerModeEnabled);
+      WScript.Echo("NumberOfProcessors: " + objItem.NumberOfProcessors);
+      try { WScript.Echo("OEMLogoBitmap: " + (objItem.OEMLogoBitmap.toArray()).join(",")); }
+         catch(e) { WScript.Echo("OEMLogoBitmap: null"); }
+      try { WScript.Echo("OEMStringArray: " + (objItem.OEMStringArray.toArray()).join(",")); }
+         catch(e) { WScript.Echo("OEMStringArray: null"); }
+      WScript.Echo("PartOfDomain: " + objItem.PartOfDomain);
+      WScript.Echo("PauseAfterReset: " + objItem.PauseAfterReset);
+      try { WScript.Echo("PowerManagementCapabilities: " + (objItem.PowerManagementCapabilities.toArray()).join(",")); }
+         catch(e) { WScript.Echo("PowerManagementCapabilities: null"); }
+      WScript.Echo("PowerManagementSupported: " + objItem.PowerManagementSupported);
+      WScript.Echo("PowerOnPasswordStatus: " + objItem.PowerOnPasswordStatus);
+      WScript.Echo("PowerState: " + objItem.PowerState);
+      WScript.Echo("PowerSupplyState: " + objItem.PowerSupplyState);
+      WScript.Echo("PrimaryOwnerContact: " + objItem.PrimaryOwnerContact);
+      WScript.Echo("PrimaryOwnerName: " + objItem.PrimaryOwnerName);
+      WScript.Echo("ResetCapability: " + objItem.ResetCapability);
+      WScript.Echo("ResetCount: " + objItem.ResetCount);
+      WScript.Echo("ResetLimit: " + objItem.ResetLimit);
+      try { WScript.Echo("Roles: " + (objItem.Roles.toArray()).join(",")); }
+         catch(e) { WScript.Echo("Roles: null"); }
+      WScript.Echo("Status: " + objItem.Status);
+      try { WScript.Echo("SupportContactDescription: " + (objItem.SupportContactDescription.toArray()).join(",")); }
+         catch(e) { WScript.Echo("SupportContactDescription: null"); }
+      WScript.Echo("SystemStartupDelay: " + objItem.SystemStartupDelay);
+      try { WScript.Echo("SystemStartupOptions: " + (objItem.SystemStartupOptions.toArray()).join(",")); }
+         catch(e) { WScript.Echo("SystemStartupOptions: null"); }
+      WScript.Echo("SystemStartupSetting: " + objItem.SystemStartupSetting);
+      WScript.Echo("SystemType: " + objItem.SystemType);
+      WScript.Echo("ThermalState: " + objItem.ThermalState);
+      WScript.Echo("TotalPhysicalMemory: " + objItem.TotalPhysicalMemory);
+      WScript.Echo("UserName: " + objItem.UserName);
+      WScript.Echo("WakeUpType: " + objItem.WakeUpType);
+      WScript.Echo("Workgroup: " + objItem.Workgroup);
+   }
+}
+
+function WMIDateStringToDate(dtmDate)
+{
+   if (dtmDate == null || dtmDate=="null")
+   {
+      return "null date";
+   }
+   var strDateTime;
+   if (dtmDate.substr(4, 1) == 0)
+   {
+      strDateTime = dtmDate.substr(5, 1) + "/";
+   }
+   else
+   {
+      strDateTime = dtmDate.substr(4, 2) + "/";
+   }
+   if (dtmDate.substr(6, 1) == 0)
+   {
+      strDateTime = strDateTime + dtmDate.substr(7, 1) + "/";
+   }
+   else
+   {
+      strDateTime = strDateTime + dtmDate.substr(6, 2) + "/";
+   }
+   strDateTime = strDateTime + dtmDate.substr(0, 4) + " " +
+   dtmDate.substr(8, 2) + ":" +
+   dtmDate.substr(10, 2) + ":" +
+   dtmDate.substr(12, 2);
+   return(strDateTime);
+}


### PR DESCRIPTION
First, thank you for winax. You did an epic job on enabling ActiveX in node. We have big project, implemented in WSH with hundreds of thousands of lines of code. And I was looking for a way to migrate to NodeJS for a long time. Now this dream came true. After a number of minor fixes and improvements we have wscript emulation possible and our tool (Rapise) working with NodeJS.

I've added a number of mocha tests covering the new functionality. Also you may try to install it from my fork: https://github.com/Inflectra/node-activex

If there any doubts or others reasons why this pull request may not be accepted kindly please let me know - so I can either correct or proceed with a fork.

Here is more detailed list of what was changed/added to the package.

1. Variant2Value: 
  - Null string vs empty string: we now distinguish and pass the value accordingly (like WScript does).
  - Unknown value returned as VariantObject or NULL (was returning "[Unknown]" string)
  
2. DispObjectImpl::Invoke: Support for methods with DISPID=0 (was forcing 0 to be always DISPID_VALUE property).

3. winaxsleep - We need Sleep in WScript, so we export it form winax.

4. Support for Microsoft.JScript.ArrayObject. .NET COM server may return it and JS will know that it is an array (just like WScript does).

5. connectionPoint.getMethods - return array of connection point method names. It is needed to implement WScript.Connect(obj, prefix);

6. connectionPoint remember its primary interface IID and replies to corresponding QueryInterface. It is required to work with .NET connection point containers.

7. VariantObject::NodeGet("") - returns toString rather than valueOf. Together with fixed Variant2Value it helps to work with expressions like 
  if(!obj.someprop)

8. Support for Enumerator.

9. Support for WScript (through 'nodewscript' cmd). It is designed for compatibility with legacy .js files. 95% of them may run without any midifications.

10. Unit tests (test/wscript.js & test/wscript/*.js)