### PR TITLE
Make this project usable as a library dependency in other native node projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,31 @@ console.log("Cell E4 value is", data[1][2]);
 
 - [examples/ado.js](https://github.com/durs/node-activex/blob/master/examples/ado.js)
 
+# Usage as a library
+
+The repo allows to re-use some of its code as a library for your own native node addon.
+
+To include it, install it as a normal node-dependency and then add it
+to the `"dependencies"` section of your `binding.gyp` file like this:
+```
+"dependencies": [
+  "<!(node -p \"require.resolve('winax/lib_binding.gyp')\"):lib_node_activex"
+]
+```
+
+In your code, you can then include it using:
+```cpp
+#include <node_activex.h>
+```
+
+This makes functions like `Variant2Value` or `Value2Variant` that translate between COM VARIANT and node types
+available in your code.
+Note that providing this library functionality is not the core target of this repo however,
+so importing it eg. currently declares
+all methods in the global namespace and opens the namespaces `v8` and `node`.
+
+Check the source code [`src/disp.h`](src/disp.h) and [`src/utils.h`](src/utils.h) for details.
+
 # Building
 
 This project uses Visual C++ 2013 (or later versions then support C++11 standard).

--- a/binding.gyp
+++ b/binding.gyp
@@ -11,19 +11,6 @@
       ],
       'dependencies': [      
       ]
-    },
-    {
-      'target_name': 'lib_node_activex',
-      'type': 'static_library',
-      'sources': [
-        'src/utils.cpp',
-        'src/disp.cpp'
-      ],
-      'direct_dependent_settings': {
-        'include_dirs': ['.']
-      },
-      'dependencies': [
-      ]
     }
   ]
 }

--- a/include/node_activex.h
+++ b/include/node_activex.h
@@ -4,5 +4,5 @@
 // Note that this does use the namespaces v8 and node in the current configuration
 
 #include "../src/stdafx.h"
-#include "../src/disp.h""
+#include "../src/disp.h"
 #include "../src/utils.h"

--- a/include/node_activex.h
+++ b/include/node_activex.h
@@ -1,0 +1,8 @@
+#pragma once
+
+// Include all the relevant definitions for use of the library code in a dependency.
+// Note that this does use the namespaces v8 and node in the current configuration
+
+#include "../src/stdafx.h"
+#include "../src/disp.h""
+#include "../src/utils.h"

--- a/lib_binding.gyp
+++ b/lib_binding.gyp
@@ -1,0 +1,17 @@
+{
+  'targets': [
+    {
+      'target_name': 'lib_node_activex',
+      'type': 'static_library',
+      'sources': [
+        'src/utils.cpp',
+        'src/disp.cpp'
+      ],
+      'direct_dependent_settings': {
+        'include_dirs': ['.']
+      },
+      'dependencies': [
+      ]
+    }
+  ]
+}

--- a/lib_binding.gyp
+++ b/lib_binding.gyp
@@ -7,6 +7,9 @@
         'src/utils.cpp',
         'src/disp.cpp'
       ],
+      'defines': [
+        'BUILDING_NODE_EXTENSION',
+      ],
       'direct_dependent_settings': {
         'include_dirs': ['.']
       },

--- a/lib_binding.gyp
+++ b/lib_binding.gyp
@@ -11,7 +11,7 @@
         'BUILDING_NODE_EXTENSION',
       ],
       'direct_dependent_settings': {
-        'include_dirs': ['.']
+        'include_dirs': ['include']
       },
       'dependencies': [
       ]


### PR DESCRIPTION
This is a more complete solution for #97.

Most importantly, I moved the definition to its own .gyp file so that it doesn't get compiled by default;
(Might also help with some parallel build issues).

Also, I created a new directory for the includes to make including it more easy and clear (instead of including eg. `src/disp.h` which is super confusing).

Moving everything to a namespace still is a consideration, but not an urgent one right now