### PR TITLE
Allow to use node-activex with COM Objects NOT present in the ROT

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -523,3 +523,4 @@ public:
 void WinaxSleep(const FunctionCallbackInfo<Value>& args);
 
 //-------------------------------------------------------------------------------------------------------
+HRESULT GetAccessibleObject(const wchar_t* pszWindowText, CComPtr<IUnknown>& spIUnknown);


### PR DESCRIPTION
If they are able to return an IUnknown via the Win32 API: AccessibleObjectFromWindow