### PR TITLE
Fix cross-platform install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.idea
 node_modules
 build
 npm-debug.log

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,14 +2,16 @@
   'targets': [
     {
       'target_name': 'node_activex',
-      'sources': [
-        'src/main.cpp',
-        'src/utils.cpp',
-        'src/disp.cpp'
-      ],
-      'libraries': [ 
-      ],
-      'dependencies': [      
+      'conditions': [
+        ['OS=="win"', {
+          'sources': [
+            'src/main.cpp',
+            'src/utils.cpp',
+            'src/disp.cpp'
+          ],
+          'libraries': [],
+          'dependencies': []
+        }]
       ]
     }
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "winax",
       "version": "3.4.2",
       "license": "MIT",
-      "os": [
-        "win32"
-      ],
       "bin": {
         "nodewscript": "NodeWScript.js"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "winax",
-  "version": "3.4.2",
+  "version": "3.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "winax",
-      "version": "3.4.2",
+      "version": "3.5.1",
       "license": "MIT",
       "bin": {
         "nodewscript": "NodeWScript.js"

--- a/package.json
+++ b/package.json
@@ -46,8 +46,5 @@
     "test": "mocha test"
   },
   "license": "MIT",
-  "main": "index.js",
-  "os": [
-    "win32"
-  ]
+  "main": "index.js"
 }


### PR DESCRIPTION
As discussed a few times, prebuilding for every node-version is not really feasible.

This pr removes the os-restriction and just builds an empty module on non-windows platforms. So npm install does not fail.

Should fix https://github.com/durs/node-activex/issues/89 's most common use-cases like monorepo, developing other product functionality locally, ...