### PR TITLE
GitHub Actions: Run tests on each pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,5 +16,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
+      - run: |
+          npm install -g mocha
+          mocha --expose-gc test
       - run: npm run build --if-present
       - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,5 +19,5 @@ jobs:
       - run: npm run build --if-present
       - run: |
           npm install -g mocha
-          mocha --expose-gc test
+          # mocha --expose-gc test
       - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
+      - run: npm run build --if-present
       - run: |
           npm install -g mocha
           mocha --expose-gc test
-      - run: npm run build --if-present
       - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
         os: [windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      # https://community.chocolatey.org/packages?q=Excel
+      - run: choco install office365proplus
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,7 @@ jobs:
       # https://community.chocolatey.org/packages?q=Excel
       - name: "Installing Office 365 takes about 5 minutes..."
         run: choco install office365proplus
-      - run: npm install -g mocha && mocha --expose-gc test
+      - run: |
+          npm install -g mocha
+          # mocha --expose-gc test  # Three tests will fail!
       - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+# https://docs.github.com/en/actions/use-cases-and-examples/building-and-testing/building-and-testing-nodejs
+
+name: ci
+on: [push, pull_request]
+jobs:
+  ci:
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['18.x', '20.x', '22.x']
+        os: [windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,14 @@ jobs:
         os: [windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      # https://community.chocolatey.org/packages?q=Excel
-      - run: choco install office365proplus
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm run build --if-present
-      - run: |
-          npm install -g mocha
-          # mocha --expose-gc test
+      # https://community.chocolatey.org/packages?q=Excel
+      - name: "Installing Office 365 takes about 5 minutes..."
+        run: choco install office365proplus
+      - run: npm install -g mocha && mocha --expose-gc test
       - run: npm test


### PR DESCRIPTION
https://docs.github.com/en/actions

https://docs.github.com/en/actions/use-cases-and-examples/building-and-testing/building-and-testing-nodejs

### Test results: https://github.com/cclauss/node-activex/actions

Tests fail if Microsoft Excel is not present so `choco install office365proplus` however installing Office 365 takes about 5 minutes so it would be useful to find a minimal install that allows the tests to succeed faster.
* https://community.chocolatey.org/packages?q=Excel
    * `mocha --expose-gc test ` # Three tests fail on Node.js v20+ even with Excel installed.
    * `npm test ` # All tests pass with Excel installed.