### PR TITLE
GitHub Actions: Add Node.js v23.x to the testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['18.x', '20.x', '22.x']
+        node-version: ['18.x', '20.x', '22.x', '23.x']
         os: [windows-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
https://nodejs.org/en/about/previous-releases#looking-for-latest-release-of-a-version-branch