### PR TITLE
TypeScript improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,28 @@ const data = wsh.Range("C3:E4").Value.valueOf();
 console.log("Cell E4 value is", data[1][2]);
 ```
 
+## TypeScript
+Your `tsconfig.json` needs at least the following configuration:
+
+1. [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) needs to be something other than `classic`. Depending on your `target` and `module` this might be the default. For example:
+```json
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"module": "nodenext"
+	}
+}
+```
+
+2. [`lib`](https://www.typescriptlang.org/tsconfig/#lib) needs to _**exclude**_ `ScriptHost`. It contains a conflicting global `ActiveXObject` type and is included by default. For example:
+```json
+{
+	"compilerOptions": {
+		"lib": [ "ESNext" ]
+	}
+}
+```
+
 # Tutorial and Examples
 
 - [examples/ado.js](https://github.com/durs/node-activex/blob/master/examples/ado.js)
@@ -305,4 +327,3 @@ mocha --expose-gc test
 * [somanuell](https://github.com/somanuell)
 * [Daniel-Userlane](https://github.com/Daniel-Userlane)
 * [alexeygrinevich](https://github.com/alexeygrinevich)
-

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,44 +1,42 @@
-declare module 'winax' {
-  export class Object {
-    constructor(id: string, options?: ActiveXOptions);
-    // Define properties typically found on COM objects
-    __id?: string;
-    __value?: any;
-    __type?: any[];
-    __methods?: string[];
-    __vars?: string[];
-    // Define general method signatures if any known
-    [key: string]: any;
-  }
-
-  export interface ActiveXOptions {
-    activate?: boolean; // Allow activate existing object instance
-    getobject?: boolean; // Allow using the name of the file in the ROT
-    type?: boolean;      // Allow using type information
-  }
-
-  export class Variant {
-    constructor(value?: any, type?: VariantType);
-    assign(value: any): void;
-    cast(type: VariantType): void;
-    clear(): void;
-    valueOf(): any;
-  }
-
-  export type VariantType =
-    | 'int' | 'uint' | 'int8' | 'char' | 'uint8' | 'uchar' | 'byte'
-    | 'int16' | 'short' | 'uint16' | 'ushort'
-    | 'int32' | 'uint32'
-    | 'int64' | 'long' | 'uint64' | 'ulong'
-    | 'currency' | 'float' | 'double' | 'string'
-    | 'date' | 'decimal' | 'variant' | 'null' | 'empty'
-    | 'byref' | 'pbyref';
-
-  export function cast(value: any, type: VariantType): any;
-
-  // Utility function to release COM objects
-  export function release(...objects: any[]): void;
+export class Object {
+  constructor(id: string, options?: ActiveXOptions);
+  // Define properties typically found on COM objects
+  __id?: string;
+  __value?: any;
+  __type?: any[];
+  __methods?: string[];
+  __vars?: string[];
+  // Define general method signatures if any known
+  [key: string]: any;
 }
+
+export interface ActiveXOptions {
+  activate?: boolean; // Allow activate existing object instance
+  getobject?: boolean; // Allow using the name of the file in the ROT
+  type?: boolean;      // Allow using type information
+}
+
+export class Variant {
+  constructor(value?: any, type?: VariantType);
+  assign(value: any): void;
+  cast(type: VariantType): void;
+  clear(): void;
+  valueOf(): any;
+}
+
+export type VariantType =
+  | 'int' | 'uint' | 'int8' | 'char' | 'uint8' | 'uchar' | 'byte'
+  | 'int16' | 'short' | 'uint16' | 'ushort'
+  | 'int32' | 'uint32'
+  | 'int64' | 'long' | 'uint64' | 'ulong'
+  | 'currency' | 'float' | 'double' | 'string'
+  | 'date' | 'decimal' | 'variant' | 'null' | 'empty'
+  | 'byref' | 'pbyref';
+
+export function cast(value: any, type: VariantType): any;
+
+// Utility function to release COM objects
+export function release(...objects: any[]): void;
 
 declare global {
   function ActiveXObject(id: string, options?: ActiveXObjectOptions): any;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,20 +1,19 @@
 export class Object {
-  constructor(id: string, options?: ActiveXOptions);
+  constructor(id: string, options?: ActiveXObjectOptions);
+  
   // Define properties typically found on COM objects
   __id?: string;
   __value?: any;
   __type?: any[];
   __methods?: string[];
   __vars?: string[];
+
   // Define general method signatures if any known
   [key: string]: any;
 }
 
-export interface ActiveXOptions {
-  activate?: boolean; // Allow activate existing object instance
-  getobject?: boolean; // Allow using the name of the file in the ROT
-  type?: boolean;      // Allow using type information
-}
+/** @deprecated Use `ActiveXObjectOptions` instead. */
+export interface ActiveXOptions extends ActiveXObjectOptions {}
 
 export class Variant {
   constructor(value?: any, type?: VariantType);
@@ -43,8 +42,13 @@ declare global {
   function ActiveXObject(obj: Record<string, any>): any;
 
   interface ActiveXObjectOptions {
+    /** Allow activating existing object instance. */
     activate?: boolean;
+    
+    /** Allow using the name of the file in the ROT. **/
     getobject?: boolean;
+
+    /** Allow using type information. */
     type?: boolean;
   }
 }


### PR DESCRIPTION
Three improvements to the TypeScript experience:
1. 0c41119 removes the problematic `declare module` wrapper from the type definitions. This fixes the following error: "Augmentations for the global scope can only be directly nested in external modules or ambient module declarations. ts(2669)".
2. 5c2d138 deprecates the duplicitous `ActiveXOptions` type in favor of `ActiveXObjectOptions`. I'd prefer moving this type out of the global scope, but that's tricky without a (very minor) breaking change.
3. e4e358e adds a note about the necessary `tsconfig` configuration to the README.