### PR TITLE
VariantObject::NodeGet should always return a value to avoid the error:

### DIFF
--- a/src/disp.cpp
+++ b/src/disp.cpp
@@ -1112,11 +1112,17 @@ void VariantObject::NodeGet(Local<Name> name, const PropertyCallbackInfoGetter& 
         if ((self->value.vt & VT_ARRAY) != 0) {
             args.GetReturnValue().Set((uint32_t)self->value.ArrayLength());
         }
-    }
+		else {
+			args.GetReturnValue().SetUndefined();
+		}
+	}
     else {
         Local<Function> func;
         if (clazz_methods.get(isolate, id, &func)) {
             args.GetReturnValue().Set(func);
+        }
+        else {
+            args.GetReturnValue().SetUndefined();
         }
     }
 }


### PR DESCRIPTION
Otherwise, if we have an IUnknown object cp and try cp.getSmth we get something like that (this is not catchable):

# Fatal error in , line 0
# Check failed: !IsTheHole(*slot, isolate).